### PR TITLE
add assert for min image size

### DIFF
--- a/yolact.py
+++ b/yolact.py
@@ -215,6 +215,7 @@ class PredictionModule(nn.Module):
         """ Note that priors are [x,y,width,height] where (x,y) is the center of the box. """
         global prior_cache
         size = (conv_h, conv_w)
+        assert(cfg.max_size > 350),"Segmentation does not work with too low-res images. Try providing input images with size atleast 350pix."
 
         with timer.env('makepriors'):
             if self.last_img_size != (cfg._tmp_img_w, cfg._tmp_img_h):


### PR DESCRIPTION
as segmentation does not work well if images are too low resolution.

Fixes #319 